### PR TITLE
Field range between

### DIFF
--- a/fragment_test.go
+++ b/fragment_test.go
@@ -378,6 +378,54 @@ func TestFragment_FieldRange(t *testing.T) {
 			t.Fatalf("unexpected bits: %+v", b.Bits())
 		}
 	})
+
+	t.Run("BETWEEN", func(t *testing.T) {
+		f := test.MustOpenFragment("i", "f", pilosa.ViewStandard, 0, "")
+		defer f.Close()
+
+		// Set values.
+		if _, err := f.SetFieldValue(1000, bitDepth, 382); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(2000, bitDepth, 300); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(3000, bitDepth, 2817); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(4000, bitDepth, 301); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(5000, bitDepth, 1); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(6000, bitDepth, 0); err != nil {
+			t.Fatal(err)
+		}
+
+		// Query for fields greater than (ending with unset bit).
+		if b, err := f.FieldRangeBetween(bitDepth, 300, 2817); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(b.Bits(), []uint64{1000, 2000, 3000, 4000}) {
+			t.Fatalf("unexpected bits: %+v", b.Bits())
+		}
+
+		// Query for fields greater than (ending with set bit).
+		if b, err := f.FieldRangeBetween(bitDepth, 301, 2817); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(b.Bits(), []uint64{1000, 3000, 4000}) {
+			t.Fatalf("unexpected bits: %+v", b.Bits())
+		}
+
+		// Query for fields greater than or equal to (ending with unset bit).
+		if b, err := f.FieldRangeBetween(bitDepth, 301, 2816); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(b.Bits(), []uint64{1000, 4000}) {
+			t.Fatalf("unexpected bits: %+v", b.Bits())
+		}
+
+		// Query for fields greater than or equal to (ending with set bit).
+		if b, err := f.FieldRangeBetween(bitDepth, 300, 2816); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(b.Bits(), []uint64{1000, 2000, 4000}) {
+			t.Fatalf("unexpected bits: %+v", b.Bits())
+		}
+	})
 }
 
 // Ensure a fragment can snapshot correctly.

--- a/pilosa.go
+++ b/pilosa.go
@@ -60,6 +60,7 @@ var (
 	ErrFieldValueTooLow       = errors.New("field value too low")
 	ErrFieldValueTooHigh      = errors.New("field value too high")
 	ErrInvalidRangeOperation  = errors.New("invalid range operation")
+	ErrInvalidBetweenValue    = errors.New("invalid value for between operation")
 
 	ErrInvalidView      = errors.New("invalid view")
 	ErrInvalidCacheType = errors.New("invalid cache type")

--- a/pql/ast.go
+++ b/pql/ast.go
@@ -227,6 +227,31 @@ func (cond *Condition) String() string {
 	return fmt.Sprintf("%s %s", cond.Op.String(), FormatValue(cond.Value))
 }
 
+// IntSliceValue reads cond.Value as a slice of uint64.
+// If the value is a slice of uint64 it will convert
+// it to []int64. Otherwise, if it is not a []int64 it will return an error.
+func (cond *Condition) IntSliceValue() ([]int64, error) {
+	val := cond.Value
+
+	switch tval := val.(type) {
+	case []interface{}:
+		ret := make([]int64, len(tval))
+		for i, v := range tval {
+			switch tv := v.(type) {
+			case int64:
+				ret[i] = tv
+			case uint64:
+				ret[i] = int64(tv)
+			default:
+				return nil, fmt.Errorf("unexpected value type %T in IntSliceValue, val %v", tv, tv)
+			}
+		}
+		return ret, nil
+	default:
+		return nil, fmt.Errorf("unexpected type %T in IntSliceValue, val %v", tval, tval)
+	}
+}
+
 func FormatValue(v interface{}) string {
 	switch v := v.(type) {
 	case string:

--- a/pql/ast_test.go
+++ b/pql/ast_test.go
@@ -15,6 +15,7 @@
 package pql_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/pilosa/pilosa/pql"
@@ -38,6 +39,31 @@ func TestCall_String(t *testing.T) {
 		}
 		if s := c.String(); s != `Range(field0 >= 10, frame="f")` {
 			t.Fatalf("unexpected string: %s", s)
+		}
+	})
+}
+
+// Ensure condition can handle values for BETWEEN operator.
+func TestCondition_Value(t *testing.T) {
+	t.Run("Between Values", func(t *testing.T) {
+		for _, tt := range []struct {
+			val []interface{}
+			exp []int64
+		}{
+			{[]interface{}{int64(4), int64(8)}, []int64{4, 8}},
+			{[]interface{}{uint64(4), uint64(8)}, []int64{4, 8}},
+			{[]interface{}{uint64(1), uint64(2), uint64(3)}, []int64{1, 2, 3}},
+		} {
+			c := &pql.Condition{
+				Op:    pql.BETWEEN,
+				Value: tt.val,
+			}
+			v, err := c.IntSliceValue()
+			if err != nil {
+				t.Fatal(err)
+			} else if !reflect.DeepEqual(v, tt.exp) {
+				t.Fatalf("invalid between values. expected: %v, got %v", tt.exp, v)
+			}
 		}
 	})
 }

--- a/pql/parser.go
+++ b/pql/parser.go
@@ -165,7 +165,7 @@ func (p *Parser) parseArgs() (map[string]interface{}, error) {
 		var op Token
 		switch tok, pos, lit := p.scanIgnoreWhitespace(); tok {
 		case ASSIGN:
-		case EQ, LT, LTE, GT, GTE:
+		case EQ, LT, LTE, GT, GTE, BETWEEN:
 			op = tok
 		default:
 			return nil, parseErrorf(pos, "expected equals sign or comparison operator, found %q", lit)

--- a/pql/parser_test.go
+++ b/pql/parser_test.go
@@ -172,7 +172,7 @@ func TestParser_Parse(t *testing.T) {
 
 	// Parse with condition arguments.
 	t.Run("WithCondition", func(t *testing.T) {
-		q, err := pql.ParseString(`MyCall(key=foo, x == 12.25, y >= 100)`)
+		q, err := pql.ParseString(`MyCall(key=foo, x == 12.25, y >= 100, z >< [4,8])`)
 		if err != nil {
 			t.Fatal(err)
 		} else if !reflect.DeepEqual(q.Calls[0],
@@ -182,6 +182,7 @@ func TestParser_Parse(t *testing.T) {
 					"key": "foo",
 					"x":   &pql.Condition{Op: pql.EQ, Value: 12.25},
 					"y":   &pql.Condition{Op: pql.GTE, Value: int64(100)},
+					"z":   &pql.Condition{Op: pql.BETWEEN, Value: []interface{}{int64(4), int64(8)}},
 				},
 			},
 		) {

--- a/pql/scanner.go
+++ b/pql/scanner.go
@@ -73,8 +73,11 @@ func (s *Scanner) Scan() (tok Token, pos Pos, lit string) {
 		s.unread()
 		return LT, pos, string(ch)
 	case '>':
-		if next := s.read(); next == '=' {
+		next := s.read()
+		if next == '=' {
 			return GTE, pos, ">="
+		} else if next == '<' {
+			return BETWEEN, pos, "><"
 		}
 		s.unread()
 		return GT, pos, string(ch)

--- a/pql/scanner_test.go
+++ b/pql/scanner_test.go
@@ -42,6 +42,7 @@ func TestScanner_Scan(t *testing.T) {
 		{name: "LTE", s: `<=`, tok: pql.LTE, lit: `<=`},
 		{name: "GT", s: `>`, tok: pql.GT, lit: `>`},
 		{name: "GTE", s: `>=`, tok: pql.GTE, lit: `>=`},
+		{name: "BETWEEN", s: `><`, tok: pql.BETWEEN, lit: `><`},
 		{name: "COMMA", s: `,`, tok: pql.COMMA, lit: `,`},
 		{name: "LPAREN", s: `(`, tok: pql.LPAREN, lit: `(`},
 		{name: "RPAREN", s: `)`, tok: pql.RPAREN, lit: `)`},

--- a/pql/token.go
+++ b/pql/token.go
@@ -37,17 +37,18 @@ const (
 	ALL
 	keyword_end
 
-	ASSIGN // =
-	EQ     // ==
-	LT     // <
-	LTE    // <=
-	GT     // >
-	GTE    // >=
-	COMMA  // ,
-	LPAREN // (
-	RPAREN // )
-	LBRACK // (
-	RBRACK // )
+	ASSIGN  // =
+	EQ      // ==
+	LT      // <
+	LTE     // <=
+	GT      // >
+	GTE     // >=
+	BETWEEN // ><
+	COMMA   // ,
+	LPAREN  // (
+	RPAREN  // )
+	LBRACK  // (
+	RBRACK  // )
 )
 
 var tokens = [...]string{
@@ -61,17 +62,18 @@ var tokens = [...]string{
 
 	ALL: "ALL",
 
-	ASSIGN: "=",
-	EQ:     "==",
-	LT:     "<",
-	LTE:    "<=",
-	GT:     ">",
-	GTE:    ">=",
-	COMMA:  ",",
-	LPAREN: "(",
-	RPAREN: ")",
-	LBRACK: "(",
-	RBRACK: ")",
+	ASSIGN:  "=",
+	EQ:      "==",
+	LT:      "<",
+	LTE:     "<=",
+	GT:      ">",
+	GTE:     ">=",
+	BETWEEN: "><",
+	COMMA:   ",",
+	LPAREN:  "(",
+	RPAREN:  ")",
+	LBRACK:  "(",
+	RBRACK:  ")",
 }
 
 var keywords map[string]Token

--- a/view.go
+++ b/view.go
@@ -329,6 +329,20 @@ func (v *View) FieldRange(op pql.Token, bitDepth uint, predicate uint64) (*Bitma
 	return bm, nil
 }
 
+// FieldRangeBetween returns bitmaps with a field value encoding matching any
+// value between predicateMin and predicateMax.
+func (v *View) FieldRangeBetween(bitDepth uint, predicateMin, predicateMax uint64) (*Bitmap, error) {
+	bm := NewBitmap()
+	for _, frag := range v.Fragments() {
+		other, err := frag.FieldRangeBetween(bitDepth, predicateMin, predicateMax)
+		if err != nil {
+			return nil, err
+		}
+		bm = bm.Union(other)
+	}
+	return bm, nil
+}
+
 // IsInverseView returns true if the view is used for storing an inverted representation.
 func IsInverseView(name string) bool {
 	return strings.HasPrefix(name, ViewInverse)


### PR DESCRIPTION
## Overview

    Implements BETWEEN for Range queries.

    The PQL looks like:
    ```
    Range(frame=f, field0 >< [200,610])
    ```

    One thing I noticed while implementing this is that it doesn't seem
    like `FieldRange()` is used in either `Frame` or `View`; the Executor
    calls `Fragment.FieldRange()` directly. The problem with this is that
    the offset logic is calculated in the Frame, but since the Executor
    doesn't go through Frame, then the Executor also has to calculate
    the offset before calling `Fragment.FieldRange`. We should unify this
    logic somewhere. Note, this applies to both `FieldRange` and
    `FieldRangeBetween`.
Fixes #

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
