### PR TITLE
Fix panic when iterating over an empty run container.

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -444,7 +444,6 @@ func (b *Bitmap) Difference(other *Bitmap) *Bitmap {
 			output.keys = append(output.keys, key)
 			output.containers = append(output.containers, container)
 		}
-
 	}
 	return output
 }
@@ -893,6 +892,13 @@ func (itr *Iterator) Next() (v uint64, eof bool) {
 			if itr.j == -1 {
 				itr.j++
 			}
+
+			// If the container is empty, move to the next container.
+			if len(c.runs) == 0 {
+				itr.i, itr.j = itr.i+1, -1
+				continue
+			}
+
 			r := c.runs[itr.j]
 			runLength := int(r.last - r.start)
 


### PR DESCRIPTION
When the difference of two run containers resulted in an empty
container, that container would be a run container with no runs.
The Iterator was expecting there to be at least one run in
`container.runs`. This fix protects against that and adds tests
for that case.


